### PR TITLE
close #147 by adding a search shortcut activated with Slash key

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -23,12 +23,19 @@ function Nav({
   const searchQuery = queryParams.get("q");
   useEffect(() => {
     const unsubscribe = tinykeys(window, {
-      Slash: (event) => {
-        // Shortcuts should only work when the document
+      "$mod+KeyK": (event) => {
+        // Search shortcuts should only work when the
         if (document.activeElement === document.body) {
-          event.preventDefault();
-          document.getElementById("searchBar").focus();
-        } // has focus, and not necessarily when the search input has focus.
+          event.preventDefault(); // document has focus.
+          document.getElementById("search-bar").focus();
+        }
+      },
+      Slash: (event) => {
+        // Search shortcuts should only work when the
+        if (document.activeElement === document.body) {
+          event.preventDefault(); // document has focus.
+          document.getElementById("search-bar").focus();
+        }
       },
     });
     return () => {

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -30,7 +30,7 @@ function Nav({
     };
     const unsubscribe = tinykeys(window, {
       "$mod+KeyK": (event) => focusSearchBar(event),
-      Slash: (event) => focusSearchBar(event),
+      Slash: focusSearchBar,
     });
     return () => {
       unsubscribe();

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -68,7 +68,7 @@ function Nav({
 
       <div className="hidden md:flex items-center justify-end space-x-8 md:flex-1 lg:w-0">
         <Input
-          id="searchBar"
+          id="search-bar"
           name="sound-search"
           placeholder="Search sound..."
           defaultValue={searchQuery}

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -22,21 +22,15 @@ function Nav({
   const queryParams = useQuery();
   const searchQuery = queryParams.get("q");
   useEffect(() => {
+    const focusSearchBar = (event) => {
+      if (document.activeElement === document.body) {
+        event.preventDefault(); // Search shortcuts
+        document.getElementById("search-bar").focus();
+      } // should only work when the document has focus.
+    };
     const unsubscribe = tinykeys(window, {
-      "$mod+KeyK": (event) => {
-        // Search shortcuts should only work when the
-        if (document.activeElement === document.body) {
-          event.preventDefault(); // document has focus.
-          document.getElementById("search-bar").focus();
-        }
-      },
-      Slash: (event) => {
-        // Search shortcuts should only work when the
-        if (document.activeElement === document.body) {
-          event.preventDefault(); // document has focus.
-          document.getElementById("search-bar").focus();
-        }
-      },
+      "$mod+KeyK": (event) => focusSearchBar(event),
+      Slash: (event) => focusSearchBar(event),
     });
     return () => {
       unsubscribe();

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,4 +1,5 @@
-import React from "react";
+import tinykeys from "tinykeys";
+import React, { useEffect } from "react";
 import { Link, withRouter, useLocation } from "react-router-dom";
 import Button from "./components/Button";
 import Input from "./components/Input";
@@ -20,6 +21,20 @@ function Nav({
   };
   const queryParams = useQuery();
   const searchQuery = queryParams.get("q");
+  useEffect(() => {
+    const unsubscribe = tinykeys(window, {
+      Slash: (event) => {
+        // Shortcuts should only work when the document
+        if (document.activeElement === document.body) {
+          event.preventDefault();
+          document.getElementById("searchBar").focus();
+        } // has focus, and not necessarily when the search input has focus.
+      },
+    });
+    return () => {
+      unsubscribe();
+    };
+  });
   return (
     <nav className="flex justify-between items-center py-4 md:justify-start md:space-x-10">
       <div className="md:flex items-center justify-start space-x-8 md:flex-1 lg:w-0">
@@ -53,6 +68,7 @@ function Nav({
 
       <div className="hidden md:flex items-center justify-end space-x-8 md:flex-1 lg:w-0">
         <Input
+          id="searchBar"
           name="sound-search"
           placeholder="Search sound..."
           defaultValue={searchQuery}

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -29,7 +29,7 @@ function Nav({
       } // should only work when the document has focus.
     };
     const unsubscribe = tinykeys(window, {
-      "$mod+KeyK": (event) => focusSearchBar(event),
+      "$mod+KeyK": focusSearchBar,
       Slash: focusSearchBar,
     });
     return () => {


### PR DESCRIPTION
This pull request closes #147 by adding a search shortcut. If we merge this pull request, users will be able to search without finding and clicking on the search bar; they would just have to press the `/` key. We're able to add this functionality using the `tinykey` repository, which is the same repository used earlier to implement the Play/Pause button shortcut. Hope it helps!﻿
