### PR TITLE
fix alignment of homepage banner on small screens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -87,12 +87,12 @@ const App = () => {
             path={"/"}
             render={() => (
               <>
-                <div className="rounded bg-secondary text-primary text-center p-8 mt-2">
+                <header className="bg-secondary md:text-center mt-2 p-8 rounded text-primary">
                   <h1 className="font-bold text-2xl">
                     Explore A World of Sounds
                   </h1>
                   <p className="text-l pt-2 opacity-50">Explore and Download</p>
-                </div>
+                </header>
                 <SearchResults
                   fetchSearchResults={(...args) =>
                     freeSound.textSearch(...args)


### PR DESCRIPTION
This pull request fixes the alignment of the homepage banner on small screens, so that it has a left text alignment instead of a center text alignment. Text alignment is left by default, which is why I didn't add `text-left` to the `className` of the homepage banner's element. Thus, the only change needed is adding `md:text-center` to `className` of the element containing the homepage banner.

I also changed the homepage banner's element from a `<div>` to a `<header>`. I considered adding a `banner` role to the `<div>` corresponding to the homepage banner, but [the "Best Practices" section of the MDN web docs page on `banner` roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_role#Best_practices) says,

> While **it is best to use the header element and ensure it is not a descendant of any subsection of the page**, sometimes you don't have access to the underlying HTML. If this is the case, you can add the role of banner to the main header of the page with JavaScript. Identifying the page's banner in this way will help improve the site's accessibility.

(I added the bold text.) So, I decided to just use the `<header>` element instead of adding `role="banner"` to the `<div>` that used to contain the homepage banner. This also makes a small bit of progress on #189.